### PR TITLE
Include the original function params in top level function declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function createBaseAST() {
   return ast;
 }
 
-function createStubFunctionASTNode(functionName, leadingComments) {
+function createStubFunctionASTNode(functionName, leadingComments, params) {
   var node = {
     type: 'FunctionDeclaration',
     id: {
@@ -30,6 +30,9 @@ function createStubFunctionASTNode(functionName, leadingComments) {
   if (leadingComments) {
     node.leadingComments = leadingComments;
   }
+  if (params) {
+    node.params = params;
+  }
   return node;
 }
 
@@ -41,7 +44,7 @@ function _generateStubs(data, options) {
       if (node.type === 'ExpressionStatement'
         && isGlobalAssignmentExpression(node.expression)) {
         var functionName = node.expression.left.property.name;
-        stubs.push(createStubFunctionASTNode(functionName, node.leadingComments));
+        stubs.push(createStubFunctionASTNode(functionName, node.leadingComments, node.expression.right.params));
       }
     }
   });

--- a/test/fixtures/expected.js
+++ b/test/fixtures/expected.js
@@ -8,5 +8,5 @@ function foo() {
  * Leading Block Comment for boo.
  */
 // leading line comment for boo
-function boo() {
+function boo(message) {
 }

--- a/test/fixtures/source.js
+++ b/test/fixtures/source.js
@@ -8,5 +8,5 @@ global.foo = function () {
  * Leading Block Comment for boo.
  */
 // leading line comment for boo
-global.boo = function () {
+global.boo = function (message) {
 };


### PR DESCRIPTION
... so that they show up in Gsheets auto-generated documentation.