### PR TITLE
feat: use `globalThis` instead of `global` for global identifier name

### DIFF
--- a/test/fixtures/esm-source.js
+++ b/test/fixtures/esm-source.js
@@ -4,5 +4,5 @@ export { bar } from './esm-exports';
  * Leading Block Comment for foo.
  */
 // leading line comment for foo
-global.foo = foo;
+globalThis.foo = foo;
 export function boo() { };

--- a/test/fixtures/exports-generated-global-assignments-expected.js
+++ b/test/fixtures/exports-generated-global-assignments-expected.js
@@ -1,4 +1,4 @@
-global.foo = exports.foo;
-global.boo = exports.boo;
-global.test = exports.test;
-global.X = exports.X;
+globalThis.foo = exports.foo;
+globalThis.boo = exports.boo;
+globalThis.test = exports.test;
+globalThis.X = exports.X;

--- a/test/fixtures/source.js
+++ b/test/fixtures/source.js
@@ -2,27 +2,27 @@
  * Leading Block Comment for foo.
  */
 // leading line comment for foo
-global.foo = function () {
+globalThis.foo = function () {
 };
 /**
  * Leading Block Comment for boo.
  */
 // leading line comment for boo
-global.boo = function (message) {
+globalThis.boo = function (message) {
 };
 /**
  * Leading Block Comment for bar.
  */
 // leading line comment for bar
-global.bar = function() {
+globalThis.bar = function() {
 },
 /**
  * Leading Block Comment for baz.
  */
 // leading line comment for baz
-global.baz = function() {
+globalThis.baz = function() {
 };
 function test() {
 };
 var X = 'x';
-global.test = test, global.X = X;
+globalThis.test = test, globalThis.X = X;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,6 +78,22 @@ test("generate function generate entry functions from export with autoGlobalExpo
     __dirname + "/fixtures/esm-expected-autoGlobalExports.js",
     { encoding: "utf8" }
   );
+  const output = generate(source, {
+    comment: true,
+    autoGlobalExports: true,
+  });
+  t.equal(
+    output.entryPointFunctions,
+    expected,
+    "actual output will match expected"
+  );
+  t.end();
+});
+
+test("generate global assignments from export with autoGlobalExports", function (t) {
+  const source = fs.readFileSync(__dirname + "/fixtures/esm-source.js", {
+    encoding: "utf8",
+  });
   const expectedGlobalAssignments = fs.readFileSync(
     __dirname +
       "/fixtures/esm-exports-generated-global-assignments-expected.js",
@@ -89,11 +105,6 @@ test("generate function generate entry functions from export with autoGlobalExpo
     exportsIdentifierName: "__webpack_exports__",
     globalIdentifierName: "__webpack_require__.g",
   });
-  t.equal(
-    output.entryPointFunctions,
-    expected,
-    "actual output will match expected"
-  );
   t.equal(
     output.globalAssignments,
     expectedGlobalAssignments,


### PR DESCRIPTION
 If you expect the same behavior as v2, set `global` as the `globalIdentifierName` option.

close #357 